### PR TITLE
[🐸 Frogbot] Update version of com.thoughtworks.xstream:xstream to 1.4.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <webwolf.context>/</webwolf.context>
     <wiremock.version>2.27.2</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.20</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.8.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | Not Covered | com.thoughtworks.xstream:xstream:1.4.5 | com.thoughtworks.xstream:xstream 1.4.5 | [1.4.16] | CVE-2021-21351 |

</div>


### 🔬 Research Details


**Description:**
[XStream](https://x-stream.github.io/) is a Java library used for object serialization, mainly to and from XML and JSON. As it performs the notoriously dangerous action of deserialization, many vulnerabilities have been discovered in it from version 1.4.6 to 1.4.18.
This vulnerability is exploitable if XStream is used to unmarshal (by calling the XStream fromXML() method) untrusted input that could come from a user or over the network. Specifically, this vulnerability uses JNDI injection (RMI) in the `dataSource` parameter of `javax.sql.rowset.BaseRowSet` class  to circumvent the XStream default blacklist. 

The official advisory contains a sample XML file that reproduces the issue, which attackers could use as a base for a straightforward exploit, making this vulnerability much more likely to be exploited in the wild against applications that use the XStream library and accept serialized information that contains user input.

**Remediation:**
##### Development mitigations

Define a whitelist of classes that are accepted by XStream during unmarshalling, by using the built-in [XStream security API](https://x-stream.github.io/security.html#example). Here is an example for such preventive code, to be used when initializing the `XStream` library: 
```java
XStream xstream = new XStream();

// Clear out existing permissions and start a whitelist
xstream.addPermission(NoTypePermission.NONE);

// Allow some basics
xstream.addPermission(NullPermission.NULL);
xstream.addPermission(PrimitiveTypePermission.PRIMITIVES);
xstream.allowTypeHierarchy(Collection.class);

// Allow any type from the "Example" package
xstream.allowTypesByWildcard(new String[] {
    Example.class.getPackage().getName()+".*"
});

// xstream.fromXML() calls from here on out will only deserialize the whitelisted classes
```

It is also possible to implement the `setupConverter` method of XStream to register just the converters the application's use case requires. Both of these methods could block malicious conversions that are able to bypass the default blacklist implemented by XStream as was the case in previous vulnerabilities discovered in the past.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
